### PR TITLE
표준 에러 응답 & 에러 코드 정의, GlobalExceptionHandler(@RestControllerAdvice) 구현 및 전역 예외 처리 표준화

### DIFF
--- a/springboot/src/main/java/com/softlabs/aicontents/common/dto/response/ErrorResponseDTO.java
+++ b/springboot/src/main/java/com/softlabs/aicontents/common/dto/response/ErrorResponseDTO.java
@@ -2,48 +2,38 @@ package com.softlabs.aicontents.common.dto.response;
 
 import com.softlabs.aicontents.common.enums.ErrorCode;
 import com.softlabs.aicontents.common.util.TraceIdUtil;
-
 import java.time.LocalDateTime;
 
 public record ErrorResponseDTO(
-    LocalDateTime timestamp,
-    String code,
-    String message,
-    String traceId,
-    String path,
-    int status
-) {
-    
-    public static ErrorResponseDTO of(ErrorCode errorCode, String path) {
-        return new ErrorResponseDTO(
-            LocalDateTime.now(),
-            errorCode.getCode(),
-            errorCode.getMessage(),
-            TraceIdUtil.getOrCreateTraceId(),
-            path,
-            errorCode.getStatus()
-        );
-    }
-    
-    public static ErrorResponseDTO of(ErrorCode errorCode, String path, String customMessage) {
-        return new ErrorResponseDTO(
-            LocalDateTime.now(),
-            errorCode.getCode(),
-            customMessage,
-            TraceIdUtil.getOrCreateTraceId(),
-            path,
-            errorCode.getStatus()
-        );
-    }
-    
-    public static ErrorResponseDTO ofWithTraceId(ErrorCode errorCode, String path, String traceId) {
-        return new ErrorResponseDTO(
-            LocalDateTime.now(),
-            errorCode.getCode(),
-            errorCode.getMessage(),
-            traceId,
-            path,
-            errorCode.getStatus()
-        );
-    }
+    LocalDateTime timestamp, String code, String message, String traceId, String path, int status) {
+
+  public static ErrorResponseDTO of(ErrorCode errorCode, String path) {
+    return new ErrorResponseDTO(
+        LocalDateTime.now(),
+        errorCode.getCode(),
+        errorCode.getMessage(),
+        TraceIdUtil.getOrCreateTraceId(),
+        path,
+        errorCode.getStatus());
+  }
+
+  public static ErrorResponseDTO of(ErrorCode errorCode, String path, String customMessage) {
+    return new ErrorResponseDTO(
+        LocalDateTime.now(),
+        errorCode.getCode(),
+        customMessage,
+        TraceIdUtil.getOrCreateTraceId(),
+        path,
+        errorCode.getStatus());
+  }
+
+  public static ErrorResponseDTO ofWithTraceId(ErrorCode errorCode, String path, String traceId) {
+    return new ErrorResponseDTO(
+        LocalDateTime.now(),
+        errorCode.getCode(),
+        errorCode.getMessage(),
+        traceId,
+        path,
+        errorCode.getStatus());
+  }
 }

--- a/springboot/src/main/java/com/softlabs/aicontents/common/enums/ErrorCode.java
+++ b/springboot/src/main/java/com/softlabs/aicontents/common/enums/ErrorCode.java
@@ -3,58 +3,58 @@ package com.softlabs.aicontents.common.enums;
 import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
-    
-    // 400번대 클라이언트 에러
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "E001", "잘못된 요청입니다."),
-    INVALID_INPUT(HttpStatus.BAD_REQUEST, "E002", "입력값이 올바르지 않습니다."),
-    MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, "E003", "필수 필드가 누락되었습니다."),
-    INVALID_FORMAT(HttpStatus.BAD_REQUEST, "E004", "올바르지 않은 형식입니다."),
-    
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E101", "인증이 필요합니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "E102", "유효하지 않은 토큰입니다."),
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "E103", "토큰이 만료되었습니다."),
-    
-    FORBIDDEN(HttpStatus.FORBIDDEN, "E201", "접근 권한이 없습니다."),
-    INSUFFICIENT_PERMISSIONS(HttpStatus.FORBIDDEN, "E202", "권한이 부족합니다."),
-    
-    NOT_FOUND(HttpStatus.NOT_FOUND, "E301", "요청한 리소스를 찾을 수 없습니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "E302", "사용자를 찾을 수 없습니다."),
-    DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "E303", "데이터를 찾을 수 없습니다."),
-    
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "E401", "허용되지 않은 HTTP 메서드입니다."),
-    
-    CONFLICT(HttpStatus.CONFLICT, "E501", "데이터 충돌이 발생했습니다."),
-    DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "E502", "이미 존재하는 리소스입니다."),
-    
-    // 500번대 서버 에러
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E901", "내부 서버 오류가 발생했습니다."),
-    DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E902", "데이터베이스 오류가 발생했습니다."),
-    EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E903", "외부 API 호출 중 오류가 발생했습니다."),
-    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "E904", "서비스를 사용할 수 없습니다.");
-    
-    private final HttpStatus httpStatus;
-    private final String code;
-    private final String message;
-    
-    ErrorCode(HttpStatus httpStatus, String code, String message) {
-        this.httpStatus = httpStatus;
-        this.code = code;
-        this.message = message;
-    }
-    
-    public HttpStatus getHttpStatus() {
-        return httpStatus;
-    }
-    
-    public String getCode() {
-        return code;
-    }
-    
-    public String getMessage() {
-        return message;
-    }
-    
-    public int getStatus() {
-        return httpStatus.value();
-    }
+
+  // 400번대 클라이언트 에러
+  BAD_REQUEST(HttpStatus.BAD_REQUEST, "E001", "잘못된 요청입니다."),
+  INVALID_INPUT(HttpStatus.BAD_REQUEST, "E002", "입력값이 올바르지 않습니다."),
+  MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, "E003", "필수 필드가 누락되었습니다."),
+  INVALID_FORMAT(HttpStatus.BAD_REQUEST, "E004", "올바르지 않은 형식입니다."),
+
+  UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E101", "인증이 필요합니다."),
+  INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "E102", "유효하지 않은 토큰입니다."),
+  TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "E103", "토큰이 만료되었습니다."),
+
+  FORBIDDEN(HttpStatus.FORBIDDEN, "E201", "접근 권한이 없습니다."),
+  INSUFFICIENT_PERMISSIONS(HttpStatus.FORBIDDEN, "E202", "권한이 부족합니다."),
+
+  NOT_FOUND(HttpStatus.NOT_FOUND, "E301", "요청한 리소스를 찾을 수 없습니다."),
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "E302", "사용자를 찾을 수 없습니다."),
+  DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "E303", "데이터를 찾을 수 없습니다."),
+
+  METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "E401", "허용되지 않은 HTTP 메서드입니다."),
+
+  CONFLICT(HttpStatus.CONFLICT, "E501", "데이터 충돌이 발생했습니다."),
+  DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "E502", "이미 존재하는 리소스입니다."),
+
+  // 500번대 서버 에러
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E901", "내부 서버 오류가 발생했습니다."),
+  DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E902", "데이터베이스 오류가 발생했습니다."),
+  EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E903", "외부 API 호출 중 오류가 발생했습니다."),
+  SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "E904", "서비스를 사용할 수 없습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+
+  ErrorCode(HttpStatus httpStatus, String code, String message) {
+    this.httpStatus = httpStatus;
+    this.code = code;
+    this.message = message;
+  }
+
+  public HttpStatus getHttpStatus() {
+    return httpStatus;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public int getStatus() {
+    return httpStatus.value();
+  }
 }

--- a/springboot/src/main/java/com/softlabs/aicontents/common/exception/BusinessException.java
+++ b/springboot/src/main/java/com/softlabs/aicontents/common/exception/BusinessException.java
@@ -3,66 +3,65 @@ package com.softlabs.aicontents.common.exception;
 import com.softlabs.aicontents.common.enums.ErrorCode;
 
 public class BusinessException extends RuntimeException {
-    
-    private final ErrorCode errorCode;
-    private final String customMessage;
 
-    //기본 생성자 (ErrorCode만 사용)
-    //사용 예시 throw new BusinessException(ErrorCode.USER_NOT_FOUND);
-    public BusinessException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
-        this.customMessage = null;
-    }
+  private final ErrorCode errorCode;
+  private final String customMessage;
 
-    //커스텀 메시지 사용 가능
-    //사용 예시 throw new BusinessException(ErrorCode.INVALID_INPUT, "이메일 형식이 잘못되었습니다.");
-    public BusinessException(ErrorCode errorCode, String customMessage) {
-        super(customMessage);
-        this.errorCode = errorCode;
-        this.customMessage = customMessage;
-    }
+  // 기본 생성자 (ErrorCode만 사용)
+  // 사용 예시 throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+  public BusinessException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+    this.customMessage = null;
+  }
 
-    //원인 예외(cause) 전달 가능
-    //사용 예시
-    // try {
-    //    externalApi.call();
-    //} catch (IOException e) {
-    //    throw new BusinessException(ErrorCode.EXTERNAL_API_ERROR, e);
-    //}
-    public BusinessException(ErrorCode errorCode, Throwable cause) {
-        super(errorCode.getMessage(), cause);
-        this.errorCode = errorCode;
-        this.customMessage = null;
-    }
+  // 커스텀 메시지 사용 가능
+  // 사용 예시 throw new BusinessException(ErrorCode.INVALID_INPUT, "이메일 형식이 잘못되었습니다.");
+  public BusinessException(ErrorCode errorCode, String customMessage) {
+    super(customMessage);
+    this.errorCode = errorCode;
+    this.customMessage = customMessage;
+  }
 
+  // 원인 예외(cause) 전달 가능
+  // 사용 예시
+  // try {
+  //    externalApi.call();
+  // } catch (IOException e) {
+  //    throw new BusinessException(ErrorCode.EXTERNAL_API_ERROR, e);
+  // }
+  public BusinessException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode.getMessage(), cause);
+    this.errorCode = errorCode;
+    this.customMessage = null;
+  }
 
-    //커스텀 메시지 + 원인 예외 둘 다 사용
-    //사용 예시
-    //try {
-    //    paymentGateway.call();
-    //} catch (Exception e) {
-    //    throw new BusinessException(
-    //        ErrorCode.EXTERNAL_API_ERROR,
-    //        "결제 서비스 호출 중 오류 발생",
-    //        e
-    //    );
-    //}
-    public BusinessException(ErrorCode errorCode, String customMessage, Throwable cause) {
-        super(customMessage, cause);
-        this.errorCode = errorCode;
-        this.customMessage = customMessage;
-    }
-    
-    public ErrorCode getErrorCode() {
-        return errorCode;
-    }
-    
-    public String getCustomMessage() {
-        return customMessage;
-    }
-    
-    public String getEffectiveMessage() {
-        return customMessage != null ? customMessage : errorCode.getMessage();
-    }
+  // 커스텀 메시지 + 원인 예외 둘 다 사용
+  // 사용 예시
+  // try {
+  //    paymentGateway.call();
+  // } catch (Exception e) {
+  //    throw new BusinessException(
+  //        ErrorCode.EXTERNAL_API_ERROR,
+  //        "결제 서비스 호출 중 오류 발생",
+  //        e
+  //    );
+  // }
+  public BusinessException(ErrorCode errorCode, String customMessage, Throwable cause) {
+    super(customMessage, cause);
+    this.errorCode = errorCode;
+    this.customMessage = customMessage;
+  }
+
+  public ErrorCode getErrorCode() {
+    return errorCode;
+  }
+
+  public String getCustomMessage() {
+    return customMessage;
+  }
+
+  public String getEffectiveMessage() {
+    return customMessage != null ? customMessage : errorCode.getMessage();
+  }
 }

--- a/springboot/src/main/java/com/softlabs/aicontents/common/exception/GlobalExceptionHandler.java
+++ b/springboot/src/main/java/com/softlabs/aicontents/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.softlabs.aicontents.common.exception;
 import com.softlabs.aicontents.common.dto.response.ErrorResponseDTO;
 import com.softlabs.aicontents.common.enums.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -17,191 +18,144 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
-import java.util.stream.Collectors;
-
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    
-    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-    //BusinessException에 정의된 예외 처리
-    @ExceptionHandler(BusinessException.class)
-    public ResponseEntity<ErrorResponseDTO> handleBusinessException(
-            BusinessException ex, 
-            HttpServletRequest request) {
-        
-        log.warn("Business exception occurred: {}", ex.getMessage(), ex);
-        
-        ErrorCode errorCode = ex.getErrorCode();
-        ErrorResponseDTO errorResponse = ErrorResponseDTO.of(
-            errorCode, 
-            request.getRequestURI(),
-            ex.getEffectiveMessage()
-        );
-        
-        return ResponseEntity
-            .status(errorCode.getHttpStatus())
-            .body(errorResponse);
-    }
+  private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-    //@Valid나 @Validated 검증 실패 시 발생하는 예외 처리 ex)이메일 형식이 잘못되었을 때, 비밀번호 최소 몇 자 이상 등
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponseDTO> handleValidationException(
-            MethodArgumentNotValidException ex,
-            HttpServletRequest request) {
-        
-        log.warn("Validation exception occurred: {}", ex.getMessage());
-        
-        String errorMessage = ex.getBindingResult()
-            .getFieldErrors()
-            .stream()
+  // BusinessException에 정의된 예외 처리
+  @ExceptionHandler(BusinessException.class)
+  public ResponseEntity<ErrorResponseDTO> handleBusinessException(
+      BusinessException ex, HttpServletRequest request) {
+
+    log.warn("Business exception occurred: {}", ex.getMessage(), ex);
+
+    ErrorCode errorCode = ex.getErrorCode();
+    ErrorResponseDTO errorResponse =
+        ErrorResponseDTO.of(errorCode, request.getRequestURI(), ex.getEffectiveMessage());
+
+    return ResponseEntity.status(errorCode.getHttpStatus()).body(errorResponse);
+  }
+
+  // @Valid나 @Validated 검증 실패 시 발생하는 예외 처리 ex)이메일 형식이 잘못되었을 때, 비밀번호 최소 몇 자 이상 등
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponseDTO> handleValidationException(
+      MethodArgumentNotValidException ex, HttpServletRequest request) {
+
+    log.warn("Validation exception occurred: {}", ex.getMessage());
+
+    String errorMessage =
+        ex.getBindingResult().getFieldErrors().stream()
             .map(FieldError::getDefaultMessage)
             .collect(Collectors.joining(", "));
-        
-        ErrorResponseDTO errorResponse = ErrorResponseDTO.of(
-            ErrorCode.INVALID_INPUT,
-            request.getRequestURI(),
-            "입력값 검증 실패: " + errorMessage
-        );
-        
-        return ResponseEntity
-            .status(ErrorCode.INVALID_INPUT.getHttpStatus())
-            .body(errorResponse);
-    }
 
-    //요청 데이터를 객체로 바인딩할 때 타입 불일치나 값 변환 실패가 발생하면 BindException이 발생. ex)검색어 누락 -> 검색어는 필수입니다.
-    @ExceptionHandler(BindException.class)
-    public ResponseEntity<ErrorResponseDTO> handleBindException(
-            BindException ex,
-            HttpServletRequest request) {
-        
-        log.warn("Bind exception occurred: {}", ex.getMessage());
-        
-        String errorMessage = ex.getBindingResult()
-            .getFieldErrors()
-            .stream()
+    ErrorResponseDTO errorResponse =
+        ErrorResponseDTO.of(
+            ErrorCode.INVALID_INPUT, request.getRequestURI(), "입력값 검증 실패: " + errorMessage);
+
+    return ResponseEntity.status(ErrorCode.INVALID_INPUT.getHttpStatus()).body(errorResponse);
+  }
+
+  // 요청 데이터를 객체로 바인딩할 때 타입 불일치나 값 변환 실패가 발생하면 BindException이 발생. ex)검색어 누락 -> 검색어는 필수입니다.
+  @ExceptionHandler(BindException.class)
+  public ResponseEntity<ErrorResponseDTO> handleBindException(
+      BindException ex, HttpServletRequest request) {
+
+    log.warn("Bind exception occurred: {}", ex.getMessage());
+
+    String errorMessage =
+        ex.getBindingResult().getFieldErrors().stream()
             .map(FieldError::getDefaultMessage)
             .collect(Collectors.joining(", "));
-        
-        ErrorResponseDTO errorResponse = ErrorResponseDTO.of(
-            ErrorCode.INVALID_INPUT,
-            request.getRequestURI(),
-            "바인딩 오류: " + errorMessage
-        );
-        
-        return ResponseEntity
-            .status(ErrorCode.INVALID_INPUT.getHttpStatus())
-            .body(errorResponse);
-    }
 
-    //필수 쿼리 파라미터가 요청에서 빠졌을 때 발생. ex) id 파라미터 누락
-    @ExceptionHandler(MissingServletRequestParameterException.class)
-    public ResponseEntity<ErrorResponseDTO> handleMissingParameterException(
-            MissingServletRequestParameterException ex,
-            HttpServletRequest request) {
-        
-        log.warn("Missing parameter exception occurred: {}", ex.getMessage());
-        
-        ErrorResponseDTO errorResponse = ErrorResponseDTO.of(
+    ErrorResponseDTO errorResponse =
+        ErrorResponseDTO.of(
+            ErrorCode.INVALID_INPUT, request.getRequestURI(), "바인딩 오류: " + errorMessage);
+
+    return ResponseEntity.status(ErrorCode.INVALID_INPUT.getHttpStatus()).body(errorResponse);
+  }
+
+  // 필수 쿼리 파라미터가 요청에서 빠졌을 때 발생. ex) id 파라미터 누락
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<ErrorResponseDTO> handleMissingParameterException(
+      MissingServletRequestParameterException ex, HttpServletRequest request) {
+
+    log.warn("Missing parameter exception occurred: {}", ex.getMessage());
+
+    ErrorResponseDTO errorResponse =
+        ErrorResponseDTO.of(
             ErrorCode.MISSING_REQUIRED_FIELD,
             request.getRequestURI(),
-            "필수 파라미터 누락: " + ex.getParameterName()
-        );
-        
-        return ResponseEntity
-            .status(ErrorCode.MISSING_REQUIRED_FIELD.getHttpStatus())
-            .body(errorResponse);
-    }
+            "필수 파라미터 누락: " + ex.getParameterName());
 
-    //요청 파라미터 또는 경로 변수의 타입 변환 실패 시 발생. ex)id가 Long이어야 하는데 "abc" 전달
-    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<ErrorResponseDTO> handleTypeMismatchException(
-            MethodArgumentTypeMismatchException ex,
-            HttpServletRequest request) {
-        
-        log.warn("Type mismatch exception occurred: {}", ex.getMessage());
-        
-        ErrorResponseDTO errorResponse = ErrorResponseDTO.of(
-            ErrorCode.INVALID_FORMAT,
-            request.getRequestURI(),
-            "잘못된 파라미터 타입: " + ex.getName()
-        );
-        
-        return ResponseEntity
-            .status(ErrorCode.INVALID_FORMAT.getHttpStatus())
-            .body(errorResponse);
-    }
+    return ResponseEntity.status(ErrorCode.MISSING_REQUIRED_FIELD.getHttpStatus())
+        .body(errorResponse);
+  }
 
-    //요청 바디(JSON 등)를 Spring이 읽거나 파싱할 수 없을 때 발생. ex) JSON 문법 오류, 잘못된 타입, 비어있는 본문 등.
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ErrorResponseDTO> handleHttpMessageNotReadableException(
-            HttpMessageNotReadableException ex,
-            HttpServletRequest request) {
-        
-        log.warn("Http message not readable exception occurred: {}", ex.getMessage());
-        
-        ErrorResponseDTO errorResponse = ErrorResponseDTO.of(
-            ErrorCode.INVALID_FORMAT,
-            request.getRequestURI(),
-            "요청 본문을 읽을 수 없습니다."
-        );
-        
-        return ResponseEntity
-            .status(ErrorCode.INVALID_FORMAT.getHttpStatus())
-            .body(errorResponse);
-    }
+  // 요청 파라미터 또는 경로 변수의 타입 변환 실패 시 발생. ex)id가 Long이어야 하는데 "abc" 전달
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ErrorResponseDTO> handleTypeMismatchException(
+      MethodArgumentTypeMismatchException ex, HttpServletRequest request) {
 
-    //지원하지 않는 HTTP 메서드를 호출할 때 발생. ex)GET 요청을 보냈지만 컨트롤러는 POST만 지원
-    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    public ResponseEntity<ErrorResponseDTO> handleMethodNotSupportedException(
-            HttpRequestMethodNotSupportedException ex,
-            HttpServletRequest request) {
-        
-        log.warn("Method not supported exception occurred: {}", ex.getMessage());
-        
-        ErrorResponseDTO errorResponse = ErrorResponseDTO.of(
-            ErrorCode.METHOD_NOT_ALLOWED,
-            request.getRequestURI()
-        );
-        
-        return ResponseEntity
-            .status(ErrorCode.METHOD_NOT_ALLOWED.getHttpStatus())
-            .body(errorResponse);
-    }
+    log.warn("Type mismatch exception occurred: {}", ex.getMessage());
 
-    //매핑된 컨트롤러(핸들러)가 없는 잘못된 URL 호출 시 발생.
-    @ExceptionHandler(NoHandlerFoundException.class)
-    public ResponseEntity<ErrorResponseDTO> handleNoHandlerFoundException(
-            NoHandlerFoundException ex,
-            HttpServletRequest request) {
-        
-        log.warn("No handler found exception occurred: {}", ex.getMessage());
-        
-        ErrorResponseDTO errorResponse = ErrorResponseDTO.of(
-            ErrorCode.NOT_FOUND,
-            request.getRequestURI()
-        );
-        
-        return ResponseEntity
-            .status(ErrorCode.NOT_FOUND.getHttpStatus())
-            .body(errorResponse);
-    }
+    ErrorResponseDTO errorResponse =
+        ErrorResponseDTO.of(
+            ErrorCode.INVALID_FORMAT, request.getRequestURI(), "잘못된 파라미터 타입: " + ex.getName());
 
-    //위에서 처리하지 못한 모든 예외를 처리하는 최후의 방어선.
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponseDTO> handleGeneralException(
-            Exception ex,
-            HttpServletRequest request) {
-        
-        log.error("Unexpected exception occurred: {}", ex.getMessage(), ex);
-        
-        ErrorResponseDTO errorResponse = ErrorResponseDTO.of(
-            ErrorCode.INTERNAL_SERVER_ERROR,
-            request.getRequestURI()
-        );
-        
-        return ResponseEntity
-            .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
-            .body(errorResponse);
-    }
+    return ResponseEntity.status(ErrorCode.INVALID_FORMAT.getHttpStatus()).body(errorResponse);
+  }
+
+  // 요청 바디(JSON 등)를 Spring이 읽거나 파싱할 수 없을 때 발생. ex) JSON 문법 오류, 잘못된 타입, 비어있는 본문 등.
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ErrorResponseDTO> handleHttpMessageNotReadableException(
+      HttpMessageNotReadableException ex, HttpServletRequest request) {
+
+    log.warn("Http message not readable exception occurred: {}", ex.getMessage());
+
+    ErrorResponseDTO errorResponse =
+        ErrorResponseDTO.of(ErrorCode.INVALID_FORMAT, request.getRequestURI(), "요청 본문을 읽을 수 없습니다.");
+
+    return ResponseEntity.status(ErrorCode.INVALID_FORMAT.getHttpStatus()).body(errorResponse);
+  }
+
+  // 지원하지 않는 HTTP 메서드를 호출할 때 발생. ex)GET 요청을 보냈지만 컨트롤러는 POST만 지원
+  @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+  public ResponseEntity<ErrorResponseDTO> handleMethodNotSupportedException(
+      HttpRequestMethodNotSupportedException ex, HttpServletRequest request) {
+
+    log.warn("Method not supported exception occurred: {}", ex.getMessage());
+
+    ErrorResponseDTO errorResponse =
+        ErrorResponseDTO.of(ErrorCode.METHOD_NOT_ALLOWED, request.getRequestURI());
+
+    return ResponseEntity.status(ErrorCode.METHOD_NOT_ALLOWED.getHttpStatus()).body(errorResponse);
+  }
+
+  // 매핑된 컨트롤러(핸들러)가 없는 잘못된 URL 호출 시 발생.
+  @ExceptionHandler(NoHandlerFoundException.class)
+  public ResponseEntity<ErrorResponseDTO> handleNoHandlerFoundException(
+      NoHandlerFoundException ex, HttpServletRequest request) {
+
+    log.warn("No handler found exception occurred: {}", ex.getMessage());
+
+    ErrorResponseDTO errorResponse =
+        ErrorResponseDTO.of(ErrorCode.NOT_FOUND, request.getRequestURI());
+
+    return ResponseEntity.status(ErrorCode.NOT_FOUND.getHttpStatus()).body(errorResponse);
+  }
+
+  // 위에서 처리하지 못한 모든 예외를 처리하는 최후의 방어선.
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponseDTO> handleGeneralException(
+      Exception ex, HttpServletRequest request) {
+
+    log.error("Unexpected exception occurred: {}", ex.getMessage(), ex);
+
+    ErrorResponseDTO errorResponse =
+        ErrorResponseDTO.of(ErrorCode.INTERNAL_SERVER_ERROR, request.getRequestURI());
+
+    return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+        .body(errorResponse);
+  }
 }

--- a/springboot/src/test/java/com/softlabs/aicontents/common/dto/response/ErrorResponseDTOTest.java
+++ b/springboot/src/test/java/com/softlabs/aicontents/common/dto/response/ErrorResponseDTOTest.java
@@ -1,109 +1,106 @@
 package com.softlabs.aicontents.common.dto.response;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.softlabs.aicontents.common.enums.ErrorCode;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.time.LocalDateTime;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mockStatic;
 
 @ExtendWith(MockitoExtension.class)
 class ErrorResponseDTOTest {
-    
-    @Test
-    void testErrorResponseCreationWithPath() {
-        String path = "/api/test";
-        ErrorCode errorCode = ErrorCode.NOT_FOUND;
-        
-        ErrorResponseDTO response = ErrorResponseDTO.of(errorCode, path);
-        
-        assertThat(response.code()).isEqualTo(errorCode.getCode());
-        assertThat(response.message()).isEqualTo(errorCode.getMessage());
-        assertThat(response.path()).isEqualTo(path);
-        assertThat(response.status()).isEqualTo(errorCode.getStatus());
-        assertThat(response.timestamp()).isNotNull();
-        assertThat(response.traceId()).isNotNull();
-    }
-    
-    @Test
-    void testErrorResponseCreationWithCustomMessage() {
-        String path = "/api/test";
-        String customMessage = "사용자 정의 오류 메시지";
-        ErrorCode errorCode = ErrorCode.INVALID_INPUT;
-        
-        ErrorResponseDTO response = ErrorResponseDTO.of(errorCode, path, customMessage);
-        
-        assertThat(response.code()).isEqualTo(errorCode.getCode());
-        assertThat(response.message()).isEqualTo(customMessage);
-        assertThat(response.path()).isEqualTo(path);
-        assertThat(response.status()).isEqualTo(errorCode.getStatus());
-        assertThat(response.timestamp()).isNotNull();
-        assertThat(response.traceId()).isNotNull();
-    }
-    
-    @Test
-    void testErrorResponseCreationWithCustomTraceId() {
-        String path = "/api/test";
-        String customTraceId = "custom-trace-123";
-        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
-        
-        ErrorResponseDTO response = ErrorResponseDTO.ofWithTraceId(errorCode, path, customTraceId);
-        
-        assertThat(response.code()).isEqualTo(errorCode.getCode());
-        assertThat(response.message()).isEqualTo(errorCode.getMessage());
-        assertThat(response.path()).isEqualTo(path);
-        assertThat(response.status()).isEqualTo(errorCode.getStatus());
-        assertThat(response.timestamp()).isNotNull();
-        assertThat(response.traceId()).isEqualTo(customTraceId);
-    }
-    
-    @Test
-    void testErrorResponseTimestamp() {
-        LocalDateTime beforeCreation = LocalDateTime.now().minusSeconds(1);
-        
-        ErrorResponseDTO response = ErrorResponseDTO.of(ErrorCode.BAD_REQUEST, "/api/test");
-        
-        LocalDateTime afterCreation = LocalDateTime.now().plusSeconds(1);
-        
-        assertThat(response.timestamp()).isBetween(beforeCreation, afterCreation);
-    }
-    
-    @Test
-    void testErrorResponseWithDifferentErrorCodes() {
-        String path = "/api/test";
-        
-        ErrorResponseDTO badRequestResponse = ErrorResponseDTO.of(ErrorCode.BAD_REQUEST, path);
-        assertThat(badRequestResponse.status()).isEqualTo(400);
-        assertThat(badRequestResponse.code()).isEqualTo("E001");
-        
-        ErrorResponseDTO unauthorizedResponse = ErrorResponseDTO.of(ErrorCode.UNAUTHORIZED, path);
-        assertThat(unauthorizedResponse.status()).isEqualTo(401);
-        assertThat(unauthorizedResponse.code()).isEqualTo("E101");
-        
-        ErrorResponseDTO notFoundResponse = ErrorResponseDTO.of(ErrorCode.NOT_FOUND, path);
-        assertThat(notFoundResponse.status()).isEqualTo(404);
-        assertThat(notFoundResponse.code()).isEqualTo("E301");
-        
-        ErrorResponseDTO serverErrorResponse = ErrorResponseDTO.of(ErrorCode.INTERNAL_SERVER_ERROR, path);
-        assertThat(serverErrorResponse.status()).isEqualTo(500);
-        assertThat(serverErrorResponse.code()).isEqualTo("E901");
-    }
-    
-    @Test
-    void testErrorResponseImmutability() {
-        ErrorCode errorCode = ErrorCode.FORBIDDEN;
-        String path = "/api/forbidden";
-        
-        ErrorResponseDTO response = ErrorResponseDTO.of(errorCode, path);
-        
-        assertThat(response.code()).isEqualTo(errorCode.getCode());
-        assertThat(response.message()).isEqualTo(errorCode.getMessage());
-        assertThat(response.path()).isEqualTo(path);
-        assertThat(response.status()).isEqualTo(errorCode.getStatus());
-    }
+
+  @Test
+  void testErrorResponseCreationWithPath() {
+    String path = "/api/test";
+    ErrorCode errorCode = ErrorCode.NOT_FOUND;
+
+    ErrorResponseDTO response = ErrorResponseDTO.of(errorCode, path);
+
+    assertThat(response.code()).isEqualTo(errorCode.getCode());
+    assertThat(response.message()).isEqualTo(errorCode.getMessage());
+    assertThat(response.path()).isEqualTo(path);
+    assertThat(response.status()).isEqualTo(errorCode.getStatus());
+    assertThat(response.timestamp()).isNotNull();
+    assertThat(response.traceId()).isNotNull();
+  }
+
+  @Test
+  void testErrorResponseCreationWithCustomMessage() {
+    String path = "/api/test";
+    String customMessage = "사용자 정의 오류 메시지";
+    ErrorCode errorCode = ErrorCode.INVALID_INPUT;
+
+    ErrorResponseDTO response = ErrorResponseDTO.of(errorCode, path, customMessage);
+
+    assertThat(response.code()).isEqualTo(errorCode.getCode());
+    assertThat(response.message()).isEqualTo(customMessage);
+    assertThat(response.path()).isEqualTo(path);
+    assertThat(response.status()).isEqualTo(errorCode.getStatus());
+    assertThat(response.timestamp()).isNotNull();
+    assertThat(response.traceId()).isNotNull();
+  }
+
+  @Test
+  void testErrorResponseCreationWithCustomTraceId() {
+    String path = "/api/test";
+    String customTraceId = "custom-trace-123";
+    ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+
+    ErrorResponseDTO response = ErrorResponseDTO.ofWithTraceId(errorCode, path, customTraceId);
+
+    assertThat(response.code()).isEqualTo(errorCode.getCode());
+    assertThat(response.message()).isEqualTo(errorCode.getMessage());
+    assertThat(response.path()).isEqualTo(path);
+    assertThat(response.status()).isEqualTo(errorCode.getStatus());
+    assertThat(response.timestamp()).isNotNull();
+    assertThat(response.traceId()).isEqualTo(customTraceId);
+  }
+
+  @Test
+  void testErrorResponseTimestamp() {
+    LocalDateTime beforeCreation = LocalDateTime.now().minusSeconds(1);
+
+    ErrorResponseDTO response = ErrorResponseDTO.of(ErrorCode.BAD_REQUEST, "/api/test");
+
+    LocalDateTime afterCreation = LocalDateTime.now().plusSeconds(1);
+
+    assertThat(response.timestamp()).isBetween(beforeCreation, afterCreation);
+  }
+
+  @Test
+  void testErrorResponseWithDifferentErrorCodes() {
+    String path = "/api/test";
+
+    ErrorResponseDTO badRequestResponse = ErrorResponseDTO.of(ErrorCode.BAD_REQUEST, path);
+    assertThat(badRequestResponse.status()).isEqualTo(400);
+    assertThat(badRequestResponse.code()).isEqualTo("E001");
+
+    ErrorResponseDTO unauthorizedResponse = ErrorResponseDTO.of(ErrorCode.UNAUTHORIZED, path);
+    assertThat(unauthorizedResponse.status()).isEqualTo(401);
+    assertThat(unauthorizedResponse.code()).isEqualTo("E101");
+
+    ErrorResponseDTO notFoundResponse = ErrorResponseDTO.of(ErrorCode.NOT_FOUND, path);
+    assertThat(notFoundResponse.status()).isEqualTo(404);
+    assertThat(notFoundResponse.code()).isEqualTo("E301");
+
+    ErrorResponseDTO serverErrorResponse =
+        ErrorResponseDTO.of(ErrorCode.INTERNAL_SERVER_ERROR, path);
+    assertThat(serverErrorResponse.status()).isEqualTo(500);
+    assertThat(serverErrorResponse.code()).isEqualTo("E901");
+  }
+
+  @Test
+  void testErrorResponseImmutability() {
+    ErrorCode errorCode = ErrorCode.FORBIDDEN;
+    String path = "/api/forbidden";
+
+    ErrorResponseDTO response = ErrorResponseDTO.of(errorCode, path);
+
+    assertThat(response.code()).isEqualTo(errorCode.getCode());
+    assertThat(response.message()).isEqualTo(errorCode.getMessage());
+    assertThat(response.path()).isEqualTo(path);
+    assertThat(response.status()).isEqualTo(errorCode.getStatus());
+  }
 }

--- a/springboot/src/test/java/com/softlabs/aicontents/common/enums/ErrorCodeTest.java
+++ b/springboot/src/test/java/com/softlabs/aicontents/common/enums/ErrorCodeTest.java
@@ -1,71 +1,71 @@
 package com.softlabs.aicontents.common.enums;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 class ErrorCodeTest {
-    
-    @Test
-    void testErrorCodeProperties() {
-        ErrorCode errorCode = ErrorCode.INVALID_INPUT;
-        
-        assertThat(errorCode.getHttpStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(errorCode.getCode()).isEqualTo("E002");
-        assertThat(errorCode.getMessage()).isEqualTo("입력값이 올바르지 않습니다.");
-        assertThat(errorCode.getStatus()).isEqualTo(400);
+
+  @Test
+  void testErrorCodeProperties() {
+    ErrorCode errorCode = ErrorCode.INVALID_INPUT;
+
+    assertThat(errorCode.getHttpStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(errorCode.getCode()).isEqualTo("E002");
+    assertThat(errorCode.getMessage()).isEqualTo("입력값이 올바르지 않습니다.");
+    assertThat(errorCode.getStatus()).isEqualTo(400);
+  }
+
+  @Test
+  void testAllErrorCodesHaveValidProperties() {
+    for (ErrorCode errorCode : ErrorCode.values()) {
+      assertThat(errorCode.getHttpStatus()).isNotNull();
+      assertThat(errorCode.getCode()).isNotEmpty();
+      assertThat(errorCode.getMessage()).isNotEmpty();
+      assertThat(errorCode.getStatus()).isGreaterThan(0);
     }
-    
-    @Test
-    void testAllErrorCodesHaveValidProperties() {
-        for (ErrorCode errorCode : ErrorCode.values()) {
-            assertThat(errorCode.getHttpStatus()).isNotNull();
-            assertThat(errorCode.getCode()).isNotEmpty();
-            assertThat(errorCode.getMessage()).isNotEmpty();
-            assertThat(errorCode.getStatus()).isGreaterThan(0);
-        }
+  }
+
+  @Test
+  void testClientErrorCodes() {
+    assertThat(ErrorCode.BAD_REQUEST.getStatus()).isEqualTo(400);
+    assertThat(ErrorCode.UNAUTHORIZED.getStatus()).isEqualTo(401);
+    assertThat(ErrorCode.FORBIDDEN.getStatus()).isEqualTo(403);
+    assertThat(ErrorCode.NOT_FOUND.getStatus()).isEqualTo(404);
+    assertThat(ErrorCode.METHOD_NOT_ALLOWED.getStatus()).isEqualTo(405);
+    assertThat(ErrorCode.CONFLICT.getStatus()).isEqualTo(409);
+  }
+
+  @Test
+  void testServerErrorCodes() {
+    assertThat(ErrorCode.INTERNAL_SERVER_ERROR.getStatus()).isEqualTo(500);
+    assertThat(ErrorCode.SERVICE_UNAVAILABLE.getStatus()).isEqualTo(503);
+  }
+
+  @Test
+  void testErrorCodeUniqueness() {
+    ErrorCode[] errorCodes = ErrorCode.values();
+
+    for (int i = 0; i < errorCodes.length; i++) {
+      for (int j = i + 1; j < errorCodes.length; j++) {
+        assertThat(errorCodes[i].getCode())
+            .as("Error codes should be unique: %s vs %s", errorCodes[i], errorCodes[j])
+            .isNotEqualTo(errorCodes[j].getCode());
+      }
     }
-    
-    @Test
-    void testClientErrorCodes() {
-        assertThat(ErrorCode.BAD_REQUEST.getStatus()).isEqualTo(400);
-        assertThat(ErrorCode.UNAUTHORIZED.getStatus()).isEqualTo(401);
-        assertThat(ErrorCode.FORBIDDEN.getStatus()).isEqualTo(403);
-        assertThat(ErrorCode.NOT_FOUND.getStatus()).isEqualTo(404);
-        assertThat(ErrorCode.METHOD_NOT_ALLOWED.getStatus()).isEqualTo(405);
-        assertThat(ErrorCode.CONFLICT.getStatus()).isEqualTo(409);
-    }
-    
-    @Test
-    void testServerErrorCodes() {
-        assertThat(ErrorCode.INTERNAL_SERVER_ERROR.getStatus()).isEqualTo(500);
-        assertThat(ErrorCode.SERVICE_UNAVAILABLE.getStatus()).isEqualTo(503);
-    }
-    
-    @Test
-    void testErrorCodeUniqueness() {
-        ErrorCode[] errorCodes = ErrorCode.values();
-        
-        for (int i = 0; i < errorCodes.length; i++) {
-            for (int j = i + 1; j < errorCodes.length; j++) {
-                assertThat(errorCodes[i].getCode())
-                    .as("Error codes should be unique: %s vs %s", errorCodes[i], errorCodes[j])
-                    .isNotEqualTo(errorCodes[j].getCode());
-            }
-        }
-    }
-    
-    @Test
-    void testSpecificErrorCodes() {
-        ErrorCode notFound = ErrorCode.NOT_FOUND;
-        assertThat(notFound.getCode()).isEqualTo("E301");
-        assertThat(notFound.getMessage()).isEqualTo("요청한 리소스를 찾을 수 없습니다.");
-        assertThat(notFound.getHttpStatus()).isEqualTo(HttpStatus.NOT_FOUND);
-        
-        ErrorCode internalError = ErrorCode.INTERNAL_SERVER_ERROR;
-        assertThat(internalError.getCode()).isEqualTo("E901");
-        assertThat(internalError.getMessage()).isEqualTo("내부 서버 오류가 발생했습니다.");
-        assertThat(internalError.getHttpStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-    }
+  }
+
+  @Test
+  void testSpecificErrorCodes() {
+    ErrorCode notFound = ErrorCode.NOT_FOUND;
+    assertThat(notFound.getCode()).isEqualTo("E301");
+    assertThat(notFound.getMessage()).isEqualTo("요청한 리소스를 찾을 수 없습니다.");
+    assertThat(notFound.getHttpStatus()).isEqualTo(HttpStatus.NOT_FOUND);
+
+    ErrorCode internalError = ErrorCode.INTERNAL_SERVER_ERROR;
+    assertThat(internalError.getCode()).isEqualTo("E901");
+    assertThat(internalError.getMessage()).isEqualTo("내부 서버 오류가 발생했습니다.");
+    assertThat(internalError.getHttpStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+  }
 }

--- a/springboot/src/test/java/com/softlabs/aicontents/common/exception/BusinessExceptionTest.java
+++ b/springboot/src/test/java/com/softlabs/aicontents/common/exception/BusinessExceptionTest.java
@@ -1,125 +1,125 @@
 package com.softlabs.aicontents.common.exception;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.softlabs.aicontents.common.enums.ErrorCode;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 class BusinessExceptionTest {
-    
-    @Test
-    void testBusinessExceptionWithErrorCode() {
-        ErrorCode errorCode = ErrorCode.NOT_FOUND;
-        
-        BusinessException exception = new BusinessException(errorCode);
-        
-        assertThat(exception.getErrorCode()).isEqualTo(errorCode);
-        assertThat(exception.getMessage()).isEqualTo(errorCode.getMessage());
-        assertThat(exception.getCustomMessage()).isNull();
-        assertThat(exception.getEffectiveMessage()).isEqualTo(errorCode.getMessage());
-    }
-    
-    @Test
-    void testBusinessExceptionWithCustomMessage() {
-        ErrorCode errorCode = ErrorCode.INVALID_INPUT;
-        String customMessage = "사용자 정의 오류 메시지";
-        
-        BusinessException exception = new BusinessException(errorCode, customMessage);
-        
-        assertThat(exception.getErrorCode()).isEqualTo(errorCode);
-        assertThat(exception.getMessage()).isEqualTo(customMessage);
-        assertThat(exception.getCustomMessage()).isEqualTo(customMessage);
-        assertThat(exception.getEffectiveMessage()).isEqualTo(customMessage);
-    }
-    
-    @Test
-    void testBusinessExceptionWithCause() {
-        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
-        Throwable cause = new RuntimeException("원인 예외");
-        
-        BusinessException exception = new BusinessException(errorCode, cause);
-        
-        assertThat(exception.getErrorCode()).isEqualTo(errorCode);
-        assertThat(exception.getMessage()).isEqualTo(errorCode.getMessage());
-        assertThat(exception.getCause()).isEqualTo(cause);
-        assertThat(exception.getCustomMessage()).isNull();
-        assertThat(exception.getEffectiveMessage()).isEqualTo(errorCode.getMessage());
-    }
-    
-    @Test
-    void testBusinessExceptionWithCustomMessageAndCause() {
-        ErrorCode errorCode = ErrorCode.DATABASE_ERROR;
-        String customMessage = "데이터베이스 연결 실패";
-        Throwable cause = new RuntimeException("Connection timeout");
-        
-        BusinessException exception = new BusinessException(errorCode, customMessage, cause);
-        
-        assertThat(exception.getErrorCode()).isEqualTo(errorCode);
-        assertThat(exception.getMessage()).isEqualTo(customMessage);
-        assertThat(exception.getCause()).isEqualTo(cause);
-        assertThat(exception.getCustomMessage()).isEqualTo(customMessage);
-        assertThat(exception.getEffectiveMessage()).isEqualTo(customMessage);
-    }
-    
-    @Test
-    void testEffectiveMessageWithoutCustomMessage() {
-        ErrorCode errorCode = ErrorCode.FORBIDDEN;
-        BusinessException exception = new BusinessException(errorCode);
-        
-        assertThat(exception.getEffectiveMessage()).isEqualTo(errorCode.getMessage());
-    }
-    
-    @Test
-    void testEffectiveMessageWithCustomMessage() {
-        ErrorCode errorCode = ErrorCode.FORBIDDEN;
-        String customMessage = "특정 리소스에 대한 접근 권한이 없습니다";
-        BusinessException exception = new BusinessException(errorCode, customMessage);
-        
-        assertThat(exception.getEffectiveMessage()).isEqualTo(customMessage);
-    }
-    
-    @Test
-    void testBusinessExceptionInheritance() {
-        ErrorCode errorCode = ErrorCode.BAD_REQUEST;
-        BusinessException exception = new BusinessException(errorCode);
-        
-        assertThat(exception).isInstanceOf(RuntimeException.class);
-        assertThat(exception).isInstanceOf(Exception.class);
-        assertThat(exception).isInstanceOf(Throwable.class);
-    }
-    
-    @Test
-    void testBusinessExceptionWithDifferentErrorCodes() {
-        BusinessException badRequestException = new BusinessException(ErrorCode.BAD_REQUEST);
-        assertThat(badRequestException.getErrorCode()).isEqualTo(ErrorCode.BAD_REQUEST);
-        
-        BusinessException unauthorizedException = new BusinessException(ErrorCode.UNAUTHORIZED);
-        assertThat(unauthorizedException.getErrorCode()).isEqualTo(ErrorCode.UNAUTHORIZED);
-        
-        BusinessException notFoundException = new BusinessException(ErrorCode.NOT_FOUND);
-        assertThat(notFoundException.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
-        
-        BusinessException serverErrorException = new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-        assertThat(serverErrorException.getErrorCode()).isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
-    }
-    
-    @Test
-    void testBusinessExceptionMessageConsistency() {
-        ErrorCode errorCode = ErrorCode.CONFLICT;
-        BusinessException exception = new BusinessException(errorCode);
-        
-        assertThat(exception.getMessage()).isEqualTo(errorCode.getMessage());
-        assertThat(exception.getEffectiveMessage()).isEqualTo(errorCode.getMessage());
-    }
-    
-    @Test
-    void testCustomMessageOverridesDefaultMessage() {
-        ErrorCode errorCode = ErrorCode.SERVICE_UNAVAILABLE;
-        String customMessage = "현재 시스템 점검 중입니다";
-        BusinessException exception = new BusinessException(errorCode, customMessage);
-        
-        assertThat(exception.getMessage()).isEqualTo(customMessage);
-        assertThat(exception.getEffectiveMessage()).isEqualTo(customMessage);
-        assertThat(exception.getMessage()).isNotEqualTo(errorCode.getMessage());
-    }
+
+  @Test
+  void testBusinessExceptionWithErrorCode() {
+    ErrorCode errorCode = ErrorCode.NOT_FOUND;
+
+    BusinessException exception = new BusinessException(errorCode);
+
+    assertThat(exception.getErrorCode()).isEqualTo(errorCode);
+    assertThat(exception.getMessage()).isEqualTo(errorCode.getMessage());
+    assertThat(exception.getCustomMessage()).isNull();
+    assertThat(exception.getEffectiveMessage()).isEqualTo(errorCode.getMessage());
+  }
+
+  @Test
+  void testBusinessExceptionWithCustomMessage() {
+    ErrorCode errorCode = ErrorCode.INVALID_INPUT;
+    String customMessage = "사용자 정의 오류 메시지";
+
+    BusinessException exception = new BusinessException(errorCode, customMessage);
+
+    assertThat(exception.getErrorCode()).isEqualTo(errorCode);
+    assertThat(exception.getMessage()).isEqualTo(customMessage);
+    assertThat(exception.getCustomMessage()).isEqualTo(customMessage);
+    assertThat(exception.getEffectiveMessage()).isEqualTo(customMessage);
+  }
+
+  @Test
+  void testBusinessExceptionWithCause() {
+    ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+    Throwable cause = new RuntimeException("원인 예외");
+
+    BusinessException exception = new BusinessException(errorCode, cause);
+
+    assertThat(exception.getErrorCode()).isEqualTo(errorCode);
+    assertThat(exception.getMessage()).isEqualTo(errorCode.getMessage());
+    assertThat(exception.getCause()).isEqualTo(cause);
+    assertThat(exception.getCustomMessage()).isNull();
+    assertThat(exception.getEffectiveMessage()).isEqualTo(errorCode.getMessage());
+  }
+
+  @Test
+  void testBusinessExceptionWithCustomMessageAndCause() {
+    ErrorCode errorCode = ErrorCode.DATABASE_ERROR;
+    String customMessage = "데이터베이스 연결 실패";
+    Throwable cause = new RuntimeException("Connection timeout");
+
+    BusinessException exception = new BusinessException(errorCode, customMessage, cause);
+
+    assertThat(exception.getErrorCode()).isEqualTo(errorCode);
+    assertThat(exception.getMessage()).isEqualTo(customMessage);
+    assertThat(exception.getCause()).isEqualTo(cause);
+    assertThat(exception.getCustomMessage()).isEqualTo(customMessage);
+    assertThat(exception.getEffectiveMessage()).isEqualTo(customMessage);
+  }
+
+  @Test
+  void testEffectiveMessageWithoutCustomMessage() {
+    ErrorCode errorCode = ErrorCode.FORBIDDEN;
+    BusinessException exception = new BusinessException(errorCode);
+
+    assertThat(exception.getEffectiveMessage()).isEqualTo(errorCode.getMessage());
+  }
+
+  @Test
+  void testEffectiveMessageWithCustomMessage() {
+    ErrorCode errorCode = ErrorCode.FORBIDDEN;
+    String customMessage = "특정 리소스에 대한 접근 권한이 없습니다";
+    BusinessException exception = new BusinessException(errorCode, customMessage);
+
+    assertThat(exception.getEffectiveMessage()).isEqualTo(customMessage);
+  }
+
+  @Test
+  void testBusinessExceptionInheritance() {
+    ErrorCode errorCode = ErrorCode.BAD_REQUEST;
+    BusinessException exception = new BusinessException(errorCode);
+
+    assertThat(exception).isInstanceOf(RuntimeException.class);
+    assertThat(exception).isInstanceOf(Exception.class);
+    assertThat(exception).isInstanceOf(Throwable.class);
+  }
+
+  @Test
+  void testBusinessExceptionWithDifferentErrorCodes() {
+    BusinessException badRequestException = new BusinessException(ErrorCode.BAD_REQUEST);
+    assertThat(badRequestException.getErrorCode()).isEqualTo(ErrorCode.BAD_REQUEST);
+
+    BusinessException unauthorizedException = new BusinessException(ErrorCode.UNAUTHORIZED);
+    assertThat(unauthorizedException.getErrorCode()).isEqualTo(ErrorCode.UNAUTHORIZED);
+
+    BusinessException notFoundException = new BusinessException(ErrorCode.NOT_FOUND);
+    assertThat(notFoundException.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
+
+    BusinessException serverErrorException = new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+    assertThat(serverErrorException.getErrorCode()).isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
+  }
+
+  @Test
+  void testBusinessExceptionMessageConsistency() {
+    ErrorCode errorCode = ErrorCode.CONFLICT;
+    BusinessException exception = new BusinessException(errorCode);
+
+    assertThat(exception.getMessage()).isEqualTo(errorCode.getMessage());
+    assertThat(exception.getEffectiveMessage()).isEqualTo(errorCode.getMessage());
+  }
+
+  @Test
+  void testCustomMessageOverridesDefaultMessage() {
+    ErrorCode errorCode = ErrorCode.SERVICE_UNAVAILABLE;
+    String customMessage = "현재 시스템 점검 중입니다";
+    BusinessException exception = new BusinessException(errorCode, customMessage);
+
+    assertThat(exception.getMessage()).isEqualTo(customMessage);
+    assertThat(exception.getEffectiveMessage()).isEqualTo(customMessage);
+    assertThat(exception.getMessage()).isNotEqualTo(errorCode.getMessage());
+  }
 }


### PR DESCRIPTION
## PR 종류
- [x] 기능 개선
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- 전역 예외 처리(Global Exception Handling) 기능을 추가
- API에서 발생하는 다양한 예외 상황을 일관된 포맷으로 처리할 수 있도록 에러 코드, 예외 클래스, 응답 DTO, 전역 예외 핸들러 구현.
- ErrorCode Enum 추가
- BusinessException 추가
- ErrorResponseDTO 추가
- GlobalExceptionHandler 추가

## 관련 이슈- 관련된 이슈 번호를 적어주세요 
<!-- 이슈 번호를 입력하면 자동으로 연결되고, PR 머지 시 이슈가 자동으로 Close 됩니다 -->
Closes #71 #72 

## 체크리스트
- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요?
- [ ] 코드 컨벤션을 지켰나요?

## 스크린샷
필요한 경우 스크린샷을 첨부해주세요.

## 기타
커스텀 예외 클래스 (BusinessException) 만들어 뒀으니까 각자 기능 예외 처리 하실 때, RuntimeException, IllegalArgumentException, NullPointerException 사용 지양하고 BusinessException 사용하시면 됩니다. 

예외 처리 하실 때, 어떤 예외처리가 필요한지 생각해보고 ErrorCode enum에서 그 예외 처리가 어떻게 정의 되어 있는지 확인해보신 후 사용하시면 됩니다. 
정의된 예외 외에 추가로 필요한 예외가 ErrorCode enum에 없으면 저한테 추가 해달라고 요청 해주시면 됩니다.

공통 응답, 성공 응답은 샤론님이 만들어 두신 ApiResponseDto에 맞춰서 하시면 되고, 에러 응답 포맷은 ErrorResponseDto에 맞춰서 하시면 됩니다.

GlobalExceptionHandler에서 다 처리해주니까 Controller에서 try-catch문 안 쓰셔도 되고, 서비스 계층에서 BusinessException으로 예외 던지거나, 경우에 따라 try-catch 사용 하시면 됩니다. BusinessException 보시면 생성자 별로 언제 사용하는지 어떻게 사용하는지, 사용 예시 주석으로 작성해두었으니 확인하시고 사용하시면 됩니다.

